### PR TITLE
Changed the way the app reads the time on images. Now reads modified …

### DIFF
--- a/lib/rename-images.js
+++ b/lib/rename-images.js
@@ -17,7 +17,7 @@ var addCreationTime = function (file) {
       }
 
       resolve({
-        created: stats.birthtime.getTime(),
+        created: stats.mtime.getTime(),
         name: file
       })
     })


### PR DESCRIPTION
## Problem
On windows and linux the creation time gets reset with the app at runtime

## Solution 
Use modified time instead and this works across all OS 